### PR TITLE
Add iOS/macOS widget usage to readme

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -83,3 +83,5 @@ See the other repositories in this GitHub organization and our API docs (https:/
 **[Mozilla Firefox](https://github.com/usetrmnl/trmnl-firefox)** - see TRMNL content in new tabs
 
 **[Google Chrome](https://github.com/usetrmnl/trmnl-chrome)** - see TRMNL content in new tabs
+
+**[iOS/macOS Widgets](https://github.com/LitoMore/await-widgets/tree/main/widgets/trmnl)** - see TRMNL content on your Apple devices home screen or desktop


### PR DESCRIPTION
> **[iOS/macOS Widgets](https://github.com/LitoMore/await-widgets/tree/main/widgets/trmnl)** - see TRMNL content on your Apple devices home screen or desktop

<img width="1344" height="842" alt="image" src="https://github.com/user-attachments/assets/4759983a-a9c8-4cdc-a980-fe1ab27424e6" />
